### PR TITLE
Capstone/prosthetic leg

### DIFF
--- a/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
+++ b/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
@@ -54,11 +54,15 @@ const ProstheticLegGraphic = () => {
   return (
     <div
       ref={legRef}
-      onClick={(e) => e.stopPropagation()}
-      className="relative w-[1400px] h-[1400px] bg-transparent"
+  onClick={(e) => {
+    e.stopPropagation();
+    if (e.target === legRef.current) setExpanded((v) => !v); // click empty area toggles expand
+  }}
+  className="group relative w-[1400px] h-[1400px] bg-transparent"
       aria-label="Prosthetic leg graphic"
       role="region"
     >
+
       {/* ───────── Abutment Screw ───────── */}
       <div className="absolute left-[862px] top-[888px]">
         {selected === "screw" && !allGrey && (

--- a/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
+++ b/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
@@ -10,24 +10,31 @@ import Foot from "../../assets/leg-images/Foot.svg";
 
 
 /*
-- Displays all parts of a prosthetic leg.
-- Click a part → highlight it with an SVG ellipse behind it.
-- Click same part → deselect.
-- Click outside (from App.jsx) → all parts grayscale again.
+- Global expand on hover (desktop) via group-hover, and lock on click (expanded=true).
+- Click a part -> select it (blue halo + part stays in color, others grey).
+- Click the same part -> deselect (labels remain tied to expand state).
+- Click outside -> deselect, all grey, collapse.
+*/
+
+/*
+- Responsive shell scales the 1400x1400 canvas:
+  sm ≈ 0.37x, md ≈ 0.6x, lg ≈ 0.79x, xl = 1x
+- Hover expand (desktop) + click lock, outside click collapses
 */
 
 const ProstheticLegGraphic = () => {
   const [selected, setSelected] = useState(null);
-  const [allGrey, setAllGrey] = useState(false); // default full color
-  const legRef = useRef(null);
+  const [allGrey, setAllGrey] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const wrapperRef = useRef(null);
 
-  // Outside click => deselect + all grey
   useEffect(() => {
     const onDocDown = (e) => {
-      const el = legRef.current;
+      const el = wrapperRef.current;
       if (el && !el.contains(e.target)) {
         setSelected(null);
         setAllGrey(true);
+        setExpanded(false);
       }
     };
     document.addEventListener("mousedown", onDocDown, true);
@@ -38,12 +45,11 @@ const ProstheticLegGraphic = () => {
     };
   }, []);
 
-  // Single, correct handleClick
   const handleClick = (part) => {
-    setAllGrey(false); // inside click returns to color mode
+    setAllGrey(false);
+    setExpanded(true);
     setSelected((prev) => (prev === part ? null : part));
   };
-
 
   const fade = (part) =>
     allGrey || (selected && selected !== part) ? "grayscale opacity-40" : "";
@@ -51,171 +57,308 @@ const ProstheticLegGraphic = () => {
   const highlight = (part) =>
     !allGrey && selected === part ? "grayscale-0 opacity-100" : "";
 
+const labelBase =
+  "pointer-events-none px-2 py-0.5 rounded-md font-normal text-slate-800 bg-white/80 border border-slate-300 shadow-sm transition-all duration-300 " +
+  "text-[10px] sm:text-xs md:text-sm lg:text-base";
+
   return (
     <div
-      ref={legRef}
-  onClick={(e) => {
-    e.stopPropagation();
-    if (e.target === legRef.current) setExpanded((v) => !v); // click empty area toggles expand
-  }}
-  className="group relative w-[1400px] h-[1400px] bg-transparent"
+      ref={wrapperRef}
+      className={[
+        "relative mx-auto aspect-square",
+        // Width steps by common devices (no config edits)
+        "w-[300px]",               // tiny phones
+        "min-[375px]:w-[320px]",   // iPhone mini / small Android
+        "min-[430px]:w-[400px]",   // big phones (Pro Max / Pixel XL)
+        "sm:w-[520px]",            // ≥640
+        "md:w-[720px]",            // ≥768
+        "lg:w-[980px]",            // ≥1024
+        "xl:w-[1200px]",           // ≥1280
+        "2xl:w-[1400px]",          // ≥1536
+        "portrait:max-w-[92vw] landscape:max-w-[88vw]",
+      ].join(" ")}
       aria-label="Prosthetic leg graphic"
       role="region"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) setExpanded((v) => !v);
+      }}
     >
-
-      {/* ───────── Abutment Screw ───────── */}
-      <div className="absolute left-[862px] top-[888px]">
-        {selected === "screw" && !allGrey && (
-          <svg
-            className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
-            width="98"
-            height="139"
+      {/* Scaled 1400x1400 canvas */}
+      <div
+        className={[
+          "group absolute top-0 left-0 w-[1400px] h-[1400px] bg-transparent",
+          "origin-top-left transform-gpu",
+          "[transform:scale(0.215)]",
+          "min-[375px]:[transform:scale(0.23)]",
+          "min-[430px]:[transform:scale(0.285)]",
+          "sm:[transform:scale(0.37)]",
+          "md:[transform:scale(0.51)]",
+          "lg:[transform:scale(0.7)]",
+          "xl:[transform:scale(0.86)]",
+          "2xl:[transform:scale(1)]",
+        ].join(" ")}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ───────── Abutment Screw ───────── */}
+        <div
+          className={[
+            "absolute left-[862px] top-[888px]",
+            "transition-transform duration-500 ease-out",
+            "md:group-hover:translate-x-[2px] md:group-hover:-translate-y-[16px]",
+            expanded ? "translate-x-[2px] -translate-y-[16px]" : "",
+          ].join(" ")}
+        >
+          {selected === "screw" && !allGrey && (
+            <svg
+              className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
+              width="98"
+              height="139"
+            >
+              <ellipse cx="49" cy="69.5" rx="69" ry="55" fill="#64c8ff" fillOpacity={0.65} />
+            </svg>
+          )}
+          <div
+            className={[
+              "absolute top-1/2 -translate-y-1/5 -left-39",
+              labelBase,
+              expanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+              "md:group-hover:opacity-100 md:group-hover:translate-x-0",
+            ].join(" ")}
           >
-            <ellipse cx="49" cy="69.5" rx="69" ry="55" fill="#64c8ff" fillOpacity={.65} />
-          </svg>
-        )}
-        <img
-          src={abutmentScrew}
-          alt="Abutment Screw"
-          onClick={() => handleClick("screw")}
-          className={`relative w-[58px] h-[99px] cursor-pointer transition-all ${fade(
-            "screw"
-          )} ${highlight("screw")}`}
-          draggable={false}
-        />
-      </div>
+            Abutment Screw
+          </div>
+          <img
+            src={abutmentScrew}
+            alt="Abutment Screw"
+            onClick={() => handleClick("screw")}
+            className={`relative w-[58px] h-[99px] cursor-pointer transition-all ${fade("screw")} ${highlight("screw")}`}
+            draggable={false}
+          />
+        </div>
 
-      {/* ───────── Socket ───────── */}
-      <div className="absolute left-[887px] top-[984px]">
-        {selected === "socket" && !allGrey && (
-          <svg
-            className="absolute pointer-events-none left-[-25px] top-[-20px] overflow-visible"
-            width="100"
-            height="142"
+        {/* ───────── Socket ───────── */}
+        <div
+          className={[
+            "absolute left-[887px] top-[984px]",
+            "transition-transform duration-500 ease-out",
+            "md:group-hover:translate-x-[-1px] md:group-hover:-translate-y-[10px]",
+            expanded ? "translate-x-[-1px] -translate-y-[10px]" : "",
+          ].join(" ")}
+        >
+          {selected === "socket" && !allGrey && (
+            <svg
+              className="absolute pointer-events-none left-[-25px] top-[-20px] overflow-visible"
+              width="100"
+              height="142"
+            >
+              <ellipse cx="50" cy="75" rx="58" ry="59" fill="#64c8ff" fillOpacity={0.65} />
+            </svg>
+          )}
+          <div
+            className={[
+              "absolute top-1/2 -translate-y-1/2 -left-20",
+              labelBase,
+              "shadow-lg bg-white",
+              expanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+              "md:group-hover:opacity-100 md:group-hover:translate-x-0",
+            ].join(" ")}
           >
-            <ellipse cx="50" cy="75" rx="58" ry="59" fill="#64c8ff" fillOpacity={.65} />
-          </svg>
-        )}
-        <img
-          src={Socket}
-          alt="Socket"
-          onClick={() => handleClick("socket")}
-          className={`relative w-[50px] h-[102px] cursor-pointer transition-all ${fade(
-            "socket"
-          )} ${highlight("socket")}`}
-          draggable={false}
-        />
-      </div>
+            Socket
+          </div>
+          <img
+            src={Socket}
+            alt="Socket"
+            onClick={() => handleClick("socket")}
+            className={`relative w-[50px] h-[102px] cursor-pointer transition-all ${fade("socket")} ${highlight("socket")}`}
+            draggable={false}
+          />
+        </div>
 
-      {/* ───────── Knee ───────── */}
-      <div className="absolute left-[900px] top-[1092px]">
-        {selected === "knee" && !allGrey && (
-          <svg
-            className="absolute pointer-events-none left-[-20px] top-[-15px] overflow-visible"
-            width="63"
-            height="42"
+        {/* ───────── Knee ───────── */}
+        <div
+          className={[
+            "absolute left-[900px] top-[1092px]",
+            "transition-transform duration-500 ease-out",
+            "md:group-hover:-translate-y-[8px]",
+            expanded ? "translate-x-[4px] -translate-y-[8px]" : "",
+          ].join(" ")}
+        >
+          {selected === "knee" && !allGrey && (
+            <svg
+              className="absolute pointer-events-none left-[-20px] top-[-15px] overflow-visible"
+              width="63"
+              height="42"
+            >
+              <ellipse cx="31.5" cy="21" rx="35" ry="30" fill="#64c8ff" fillOpacity={0.65} />
+            </svg>
+          )}
+          <div
+            className={[
+              "absolute top-1/2 -translate-y-1/2 -left-18",
+              labelBase,
+              expanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+              "md:group-hover:opacity-100 md:group-hover:translate-x-0",
+            ].join(" ")}
           >
-            <ellipse cx="31.5" cy="21" rx="35" ry="30" fill="#64c8ff" fillOpacity={.65} />
-          </svg>
-        )}
-        <img
-          src={Knee}
-          alt="Knee"
-          onClick={() => handleClick("knee")}
-          className={`relative w-[23px] h-[12px] cursor-pointer transition-all ${fade(
-            "knee"
-          )} ${highlight("knee")}`}
-          draggable={false}
-        />
-      </div>
+            Knee
+          </div>
+          <img
+            src={Knee}
+            alt="Knee"
+            onClick={() => handleClick("knee")}
+            className={`relative w-[23px] h-[12px] cursor-pointer transition-all ${fade("knee")} ${highlight("knee")}`}
+            draggable={false}
+          />
+        </div>
 
-      {/* ───────── Calf ───────── */}
-      <div className="absolute left-[895px] top-[1106px]">
-        {selected === "calf" && !allGrey && (
-          <svg
-            className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
-            width="140"
-            height="180"
-            viewBox="0 0 140 180"
+        {/* ───────── Calf ───────── */}
+        <div
+          className={[
+            "absolute left-[895px] top-[1106px]",
+            "transition-transform duration-500 ease-out",
+            "md:group-hover:translate-x-[2px] md:group-hover:-translate-y-[2px]",
+            expanded ? "translate-x-[5px] -translate-y-[5px]" : "",
+          ].join(" ")}
+        >
+          {selected === "calf" && !allGrey && (
+            <svg
+              className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
+              width="140"
+              height="180"
+              viewBox="0 0 140 180"
+            >
+              <ellipse cx="36.5" cy="52" rx="50" ry="48" fill="#64c8ff" fillOpacity={0.65} />
+            </svg>
+          )}
+          <div
+            className={[
+              "absolute top-1/2 -translate-y-1/2 -left-15",
+              labelBase,
+              expanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+              "md:group-hover:opacity-100 md:group-hover:translate-x-0",
+            ].join(" ")}
           >
-            <ellipse cx="36.5" cy="52" rx="50" ry="48" fill="#64c8ff" fillOpacity={.65} />
-          </svg>
-        )}
-        <img
-          src={Calf}
-          alt="Calf"
-          onClick={() => handleClick("calf")}
-          className={`relative w-[33px] h-[64px] cursor-pointer transition-all ${fade(
-            "calf"
-          )} ${highlight("calf")}`}
-          draggable={false}
-        />
-      </div>
+            Calf
+          </div>
+          <img
+            src={Calf}
+            alt="Calf"
+            onClick={() => handleClick("calf")}
+            className={`relative w-[33px] h-[64px] cursor-pointer transition-all ${fade("calf")} ${highlight("calf")}`}
+            draggable={false}
+          />
+        </div>
 
-      {/* ───────── Pylon ───────── */}
-      <div className="absolute left-[907px] top-[1171px]">
-        {selected === "pylon" && !allGrey && (
-          <svg
-            className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
-            width="51"
-            height="91"
+        {/* ───────── Pylon ───────── */}
+        <div
+          className={[
+            "absolute left-[907px] top-[1171px]",
+            "transition-transform duration-500 ease-out",
+            "md:group-hover:translate-x-[4px] md:group-hover:translate-y-[2px]",
+            expanded ? "translate-x-[4px] translate-y-[2px]" : "",
+          ].join(" ")}
+        >
+          {selected === "pylon" && !allGrey && (
+            <svg
+              className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
+              width="51"
+              height="91"
+            >
+              <ellipse cx="25.5" cy="45.5" rx="40" ry="38" fill="#64c8ff" fillOpacity={0.65} />
+            </svg>
+          )}
+          <div
+            className={[
+              "absolute top-1/2 -translate-y-1/2 -left-20",
+              labelBase,
+              expanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+              "md:group-hover:opacity-100 md:group-hover:translate-x-0",
+            ].join(" ")}
           >
-            <ellipse cx="25.5" cy="45.5" rx="40" ry="38" fill="#64c8ff" fillOpacity={.65} />
-          </svg>
-        )}
-        <img
-          src={Pylon}
-          alt="Pylon"
-          onClick={() => handleClick("pylon")}
-          className={`relative w-[11px] h-[51px] cursor-pointer transition-all ${fade(
-            "pylon"
-          )} ${highlight("pylon")}`}
-          draggable={false}
-        />
-      </div>
+            Pylon
+          </div>
+          <img
+            src={Pylon}
+            alt="Pylon"
+            onClick={() => handleClick("pylon")}
+            className={`relative w-[11px] h-[51px] cursor-pointer transition-all ${fade("pylon")} ${highlight("pylon")}`}
+            draggable={false}
+          />
+        </div>
 
-      {/* ───────── Ankle ───────── */}
-      <div className="absolute left-[905px] top-[1220px]">
-        {selected === "ankle" && !allGrey && (
-          <svg
-            className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
-            width="52"
-            height="53"
+        {/* ───────── Ankle ───────── */}
+        <div
+          className={[
+            "absolute left-[906px] top-[1220px]",
+            "transition-transform duration-500 ease-out",
+            "md:group-hover:translate-x-[4px] md:group-hover:translate-y-[10px]",
+            expanded ? "translate-x-[4px] translate-y-[10px]" : "",
+          ].join(" ")}
+        >
+          {selected === "ankle" && !allGrey && (
+            <svg
+              className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
+              width="52"
+              height="53"
+            >
+              <ellipse cx="26" cy="26.5" rx="30" ry="30" fill="#64c8ff" fillOpacity={0.65} />
+            </svg>
+          )}
+          <div
+            className={[
+              "absolute top-1/3 -translate-y-1/2 -left-[80px]",
+              labelBase,
+              expanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+              "md:group-hover:opacity-100 md:group-hover:translate-x-0",
+            ].join(" ")}
           >
-            <ellipse cx="26" cy="26.5" rx="30" ry="30" fill="#64c8ff" fillOpacity={.65} />
-          </svg>
-        )}
-        <img
-          src={Ankle}
-          alt="Ankle"
-          onClick={() => handleClick("ankle")}
-          className={`relative w-[12px] h-[13px] cursor-pointer transition-all ${fade(
-            "ankle"
-          )} ${highlight("ankle")}`}
-          draggable={false}
-        />
-      </div>
+            Ankle
+          </div>
+          <img
+            src={Ankle}
+            alt="Ankle"
+            onClick={() => handleClick("ankle")}
+            className={`relative w-[12px] h-[13px] cursor-pointer transition-all ${fade("ankle")} ${highlight("ankle")}`}
+            draggable={false}
+          />
+        </div>
 
-      {/* ───────── Foot ───────── */}
-      <div className="absolute left-[872px] top-[1233px]">
-        {selected === "foot" && !allGrey && (
-          <svg
-            className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
-            width="92"
-            height="68"
+        {/* ───────── Foot ───────── */}
+        <div
+          className={[
+            "absolute left-[872px] top-[1235px]",
+            "transition-transform duration-500 ease-out",
+            "md:group-hover:translate-x-[5px] md:group-hover:translate-y-[15px]",
+            expanded ? "translate-x-[5px] translate-y-[15px]" : "",
+          ].join(" ")}
+        >
+          {selected === "foot" && !allGrey && (
+            <svg
+              className="absolute pointer-events-none left-[-20px] top-[-20px] overflow-visible"
+              width="92"
+              height="68"
+            >
+              <ellipse cx="46" cy="35" rx="45" ry="38" fill="#64c8ff" fillOpacity={0.65} />
+            </svg>
+          )}
+          <div
+            className={[
+              "absolute top-1/2 -translate-y-1 -left-15",
+              labelBase,
+              expanded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+              "md:group-hover:opacity-100 md:group-hover:translate-x-0",
+            ].join(" ")}
           >
-            <ellipse cx="46" cy="35" rx="45" ry="38" fill="#64c8ff" fillOpacity={.65} />
-          </svg>
-        )}
-        <img
-          src={Foot}
-          alt="Foot"
-          onClick={() => handleClick("foot")}
-          className={`relative w-[52px] h-[28px] cursor-pointer transition-all ${fade(
-            "foot"
-          )} ${highlight("foot")}`}
-          draggable={false}
-        />
+            Foot
+          </div>
+          <img
+            src={Foot}
+            alt="Foot"
+            onClick={() => handleClick("foot")}
+            className={`relative w-[52px] h-[28px] cursor-pointer transition-all ${fade("foot")} ${highlight("foot")}`}
+            draggable={false}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
+++ b/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
@@ -48,11 +48,22 @@ const ProstheticLegGraphic = () => {
     };
   }, []);
 
-  const handleClick = (part) => {
-    setAllGrey(false);
-    setExpanded(true);
-    setSelected((prev) => (prev === part ? null : part));
-  };
+ const handleClick = (part) => {
+  // If clicking the same part again → deselect + unlock expand
+  if (selected === part) {
+    setSelected(null);
+    setExpanded(false);
+    // Optional: also grey everything again
+    // setAllGrey(true);
+    return;
+  }
+
+  // New selection → color mode + lock expand
+  setAllGrey(false);
+  setExpanded(true);
+  setSelected(part);
+};
+
 
   const fade = (part) =>
     allGrey || (selected && selected !== part) ? "grayscale opacity-40" : "";
@@ -180,10 +191,10 @@ const labelBase =
         {/* ───────── Knee ───────── */}
         <div
           className={[
-            "absolute left-[900px] top-[1092px]",
+            "absolute left-[900px] top-[1095px]",
             "transition-transform duration-500 ease-out",
-            "md:group-hover:-translate-y-[8px]",
-            expanded ? "translate-x-[4px] -translate-y-[8px]" : "",
+            "md:group-hover:translate-x-[7px] -translate-y-[7px]",
+            expanded ? "translate-x-[2px] -translate-y-[8px]" : "",
           ].join(" ")}
         >
           {selected === "knee" && !allGrey && (

--- a/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
+++ b/src/components/prosthetic-leg/ProstheticLegGraphic.jsx
@@ -19,7 +19,10 @@ import Foot from "../../assets/leg-images/Foot.svg";
 /*
 - Responsive shell scales the 1400x1400 canvas:
   sm ≈ 0.37x, md ≈ 0.6x, lg ≈ 0.79x, xl = 1x
-- Hover expand (desktop) + click lock, outside click collapses
+- Hover expand (desktop) and click to lock expand.
+- Each part positioned absolutely within the canvas.
+- Each part has its own hover and click handlers to manage selection and highlighting.
+- Labels appear next to parts when selected or on hover (desktop).
 */
 
 const ProstheticLegGraphic = () => {
@@ -66,7 +69,7 @@ const labelBase =
       ref={wrapperRef}
       className={[
         "relative mx-auto aspect-square",
-        // Width steps by common devices (no config edits)
+        // Width steps by common devices and breakpoints
         "w-[300px]",               // tiny phones
         "min-[375px]:w-[320px]",   // iPhone mini / small Android
         "min-[430px]:w-[400px]",   // big phones (Pro Max / Pixel XL)


### PR DESCRIPTION
## Proposed changes
- Add desktop hover animations and per-part hover using named groups (`group/board`, `group/part`) so hover works when **highlighted** and when **greyscaled**.
- Implement click-to-select with halo + grayscale of non-selected parts.
- **New:** Clicking the **same part again** now **deselects** and **disengages** the locked expand state.
- Maintain outside-click to deselect, set all grey, and collapse.
- Responsive scaling for the 1400×1400 canvas across common device widths (no Tailwind config edits).
- Fix invalid Tailwind negative transform utilities (use `translate-x-[-Npx]` form).
- Medium-small label sizing with improved readability (padding/border/shadow), responsive across breakpoints.

## Link to Product Tracker
(https://www.notion.so/Leg-Graphic-Hover-Click-25d3aaf41894807395acdcbb467f070e?v=25d3aaf4189481bcb13d000c5c7b68cb&source=copy_link)

## Link to Figma/Zeplin

(https://www.figma.com/design/JuxM3rQnGbZGwAxy3JshTw/Penta-Filter-Design?node-id=0-1&p=f&t=M4bDEXieZZw1wx5l-0)

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] All apps build locally (`npm run build:all`)
- [ ] Lint and unit tests pass locally with my changes
- [x] In the case of UI changes, I have locally verified no new browser console warnings were observed
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
**Why this approach**
- Used **named groups** to separate board-level hover (`md:group-hover/board:*`) from part-level hover (`group-hover/part:*`). This ensures hover animations apply even when a part is greyscaled due to another selection.
- Ordered utilities so state classes (`expanded ? …`) appear **before** hover utilities; last class wins, allowing hover to override expanded transforms when hovering.
- Kept all sizes and transforms **absolute** and scaled the entire canvas for predictable positioning.
- No Tailwind config changes required (works with default breakpoints and arbitrary values).

**Alternatives considered**
- Single group + `supports-[hover:hover]` gating: rejected to avoid variant dependency and to retain precise per-part hover control.
- Fluid `clamp()/vw` scaling: rejected for this pixel-mapped layout to avoid drift in absolute placements.

**Behavior notes**
- Click a part → lock expand, highlight that part, grey others.
- Click the **same** part again → **deselect** and **unlock expand** (requested change).
- Click outside → deselect, set all grey, collapse.
- Mobile/touch: hover is gated to desktop; tap interaction preserved.

**Compatibility**
- Works in all modern browsers (Chrome/Edge/Firefox/Safari 15+).  

## Screenshots 
_Please attach:_
- Before:

https://github.com/user-attachments/assets/8aac8c58-7dbe-472b-a6ea-13dc10910bf7


- After:

https://github.com/user-attachments/assets/11062f73-c6f8-460d-a8f8-3b0b7c79ac7b


- Selecting and re-clicking a part to disengage expand
- Responsive sizes (≈390px, 768px, 1024px, 1280px)  

- Update:



https://github.com/user-attachments/assets/8eff9562-adf2-4e4b-ab1c-b4d8646f4890


